### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # MCP Compass 🧭
 
 [![Model Context Protocol](https://img.shields.io/badge/Model%20Context%20Protocol-purple)](https://modelcontextprotocol.org)
+[![smithery badge](https://smithery.ai/badge/@liuyoshio/mcp-compass)](https://smithery.ai/server/@liuyoshio/mcp-compass)
+
 
 ## MCP Discovery & Recommendation
 
@@ -33,14 +35,22 @@ or
 
 ### Installation
 
-For Claude Desktop, edit your `claude_desktop_config.json` file:
+#### Installing via Smithery
 
-#### MacOS/Linux
+To install Compass for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@liuyoshio/mcp-compass):
+
+```bash
+npx -y @smithery/cli install @liuyoshio/mcp-compass --client claude
+```
+
+#### For Claude Desktop, edit your `claude_desktop_config.json` file:
+
+##### MacOS/Linux
 ``` bash
 code ~/Library/Application\ Support/Claude/claude_desktop_config.json
 ```
 
-#### Windows
+##### Windows
 ``` bash
 code $env:AppData\Claude\claude_desktop_config.json
 ```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Compass for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/@liuyoshio/mcp-compass

Let me know if any tweaks have to be made!